### PR TITLE
Bug fixes for the ApiKeyProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./providers/api_key": {
+      "import": "./dist/providers/api_key.js",
+      "types": "./dist/providers/api_key.d.ts"
     }
   },
   "files": [

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -35,7 +35,7 @@ export type ErrorPayload = {
 export class RuntError extends Error {
   constructor(
     public type: ErrorType,
-    private options: ExtensionErrorOptions
+    private options: ExtensionErrorOptions = {}
   ) {
     super(options.message ?? `RuntError: ${type}`, { cause: options.cause });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { ApiKeyProvider } from './providers/api_key';
-export type * from './providers/shared';
+export * from './providers/shared';
 export * from './errors';
 
 export type BackendExtension = {

--- a/src/providers/api_key.ts
+++ b/src/providers/api_key.ts
@@ -21,6 +21,11 @@ export type ApiKey = CreateApiKeyRequest & {
   revoked: boolean;
 };
 
+export type ListApiKeysRequest = {
+  limit?: number;
+  offset?: number;
+};
+
 export type ApiKeyProvider = {
   capabilities: Set<ApiKeyCapabilities>;
   overrideHandler?: (context: ProviderContext) => Promise<false | WorkerResponse>; // Any routes the provider wants to fully implement. Return false for any route not handled
@@ -28,7 +33,7 @@ export type ApiKeyProvider = {
   validateApiKey(context: ProviderContext): Promise<Passport>; // Ensure the API key is valid, and returns the Passport. Raise an error otherwise
   createApiKey: (context: AuthenticatedProviderContext, request: CreateApiKeyRequest) => Promise<string>;
   getApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<ApiKey>; // Returns the API key matching the specific api key id
-  listApiKeys: (context: AuthenticatedProviderContext) => Promise<ApiKey[]>; // Return a list of all API keys for a user
+  listApiKeys: (context: AuthenticatedProviderContext, request: ListApiKeysRequest) => Promise<ApiKey[]>; // Return a list of all API keys for a user
   revokeApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<void>; // set the revoked flag for an API key, such that it will no longer be valid
   deleteApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<void>; // Delete an API key from the database
 };

--- a/src/providers/api_key.ts
+++ b/src/providers/api_key.ts
@@ -1,5 +1,5 @@
 import type { Response as WorkerResponse } from '@cloudflare/workers-types';
-import type { Passport, ProviderContext, Scope, Resource } from './shared';
+import type { Passport, ProviderContext, Scope, Resource, AuthenticatedProviderContext } from './shared';
 
 export enum ApiKeyCapabilities {
   Revoke = 'revoke',
@@ -26,9 +26,9 @@ export type ApiKeyProvider = {
   overrideHandler?: (context: ProviderContext) => Promise<false | WorkerResponse>; // Any routes the provider wants to fully implement. Return false for any route not handled
   isApiKey(context: ProviderContext): boolean; // Returns true if the auth token appears to be an API key (whether or not it is valid)
   validateApiKey(context: ProviderContext): Promise<Passport>; // Ensure the API key is valid, and returns the Passport. Raise an error otherwise
-  createApiKey: (context: ProviderContext, request: CreateApiKeyRequest) => Promise<string>;
-  getApiKey: (context: ProviderContext, id: string) => Promise<ApiKey>; // Returns the API key matching the specific api key id
-  listApiKeys: (context: ProviderContext) => Promise<ApiKey[]>; // Return a list of all API keys for a user
-  revokeApiKey: (context: ProviderContext, id: string) => Promise<void>; // set the revoked flag for an API key, such that it will no longer be valid
-  deleteApiKey: (context: ProviderContext, id: string) => Promise<void>; // Delete an API key from the database
+  createApiKey: (context: AuthenticatedProviderContext, request: CreateApiKeyRequest) => Promise<string>;
+  getApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<ApiKey>; // Returns the API key matching the specific api key id
+  listApiKeys: (context: AuthenticatedProviderContext) => Promise<ApiKey[]>; // Return a list of all API keys for a user
+  revokeApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<void>; // set the revoked flag for an API key, such that it will no longer be valid
+  deleteApiKey: (context: AuthenticatedProviderContext, id: string) => Promise<void>; // Delete an API key from the database
 };

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -47,4 +47,8 @@ export type ProviderContext = {
   passport: Passport | null;
 };
 
-export type AuthenticatedProviderContext = NonNullable<ProviderContext>;
+// https://github.com/microsoft/TypeScript/issues/28374
+type NonNullableValues<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+};
+export type AuthenticatedProviderContext = NonNullableValues<ProviderContext>;

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -46,3 +46,5 @@ export type ProviderContext = {
   bearerToken: string | null;
   passport: Passport | null;
 };
+
+export type AuthenticatedProviderContext = NonNullable<ProviderContext>;

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -23,7 +23,7 @@ export type User = {
   email: string;
   name?: string;
   givenName?: string;
-  familyName: string;
+  familyName?: string;
 };
 
 export type Resource = {


### PR DESCRIPTION
When actually implementing the ApiKeyProvider, several type issues were discovered. This PR fixes:

- The api_key providers entrypoint is exported so it can be imported directly
- RuntError options are optional, and the empty {} can be omitted
- ListApiKeys takes in a limit/offset value
- ApiKeyProvider passes back an AuthenticatedContext, to prevent unecessary non-null assertions
- the index exports all the values from shared, not just the types